### PR TITLE
chore(compile): update 3.1 alias

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ case "$RUBY_VERSION" in
     RUBY_VERSION_PATCHED="2.7.7"
     ;;
   3.1)
-    RUBY_VERSION_PATCHED="3.1.3"
+    RUBY_VERSION_PATCHED="3.1.4"
     ;;
   3.2)
     RUBY_VERSION_PATCHED="3.2.2"


### PR DESCRIPTION
Se esta cayendo un build porque se está reemplazando la versión incorrecta de ruby en el gemfile (3.1.3 y no 3.1.4).

Forkeamos este repo para mantenerlo actualizado segun nuestras necesidades.